### PR TITLE
changes to update spring-core version 6.0.2 to 6.0.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ plugins {
   id 'io.spinnaker.project' version "$spinnakerGradleVersion" apply false
   id "org.jetbrains.kotlin.jvm" version "$kotlinVersion" apply false
   id "org.jetbrains.kotlin.plugin.allopen" version "$kotlinVersion" apply false
-  id 'org.springframework.boot' version '3.0.0' apply true
 }
 
 allprojects {

--- a/front50-api-tck/front50-api-tck.gradle
+++ b/front50-api-tck/front50-api-tck.gradle
@@ -22,3 +22,9 @@ test {
     includeEngines "junit-jupiter"
   }
 }
+compileTestKotlin {
+  kotlinOptions {
+    languageVersion = "1.7"
+    jvmTarget = "17"
+  }
+}

--- a/front50-gcs/front50-gcs.gradle
+++ b/front50-gcs/front50-gcs.gradle
@@ -33,7 +33,7 @@ dependencies {
   }
   api("org.springframework.boot:spring-boot-starter-test")
   implementation "com.google.guava:guava"
-  implementation "com.netflix.spectator:spectator-api:1.3.7"
+  implementation "com.netflix.spectator:spectator-api:1.5.3"
   implementation "io.spinnaker.kork:kork-exceptions"
   implementation "io.github.resilience4j:resilience4j-circuitbreaker"
   implementation "io.reactivex:rxjava:1.3.8"

--- a/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/GcsIntegrationTest.kt
+++ b/front50-gcs/src/test/kotlin/com/netflix/spinnaker/front50/model/GcsIntegrationTest.kt
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnnaker.front50.model
 
+
 import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
 import com.netflix.spinnaker.front50.config.GcsConfig
 import com.netflix.spinnaker.front50.model.GcsIntegrationTestConfiguration
@@ -25,7 +26,7 @@ import com.netflix.spinnaker.front50.model.ObjectType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringExtension
@@ -36,7 +37,7 @@ import strikt.assertions.isEmpty
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(
   classes = [GcsConfig::class, GcsIntegrationTestConfiguration::class],
-  initializers = [ConfigFileApplicationContextInitializer::class]
+  initializers = [ConfigDataApplicationContextInitializer::class]
 )
 @TestPropertySource(properties = ["spring.config.location=classpath:minimal-gcs-account.yml"])
 class GcsIntegrationTest {
@@ -47,3 +48,4 @@ class GcsIntegrationTest {
     expectThat(storageService.listObjectKeys(ObjectType.PIPELINE)).hasSize(1)
   }
 }
+

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.front50.config;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
@@ -34,10 +33,7 @@ import org.springframework.context.annotation.Import;
 @Import(BastionConfig.class)
 @EnableConfigurationProperties({S3MetadataStorageProperties.class, S3PluginStorageProperties.class})
 public class S3Config {
-  @Bean
-  public AWSCredentialsProvider getAwsCredProvider() {
-    return new DefaultAWSCredentialsProviderChain();
-  }
+
   @Bean
   @ConditionalOnProperty(value = "spinnaker.s3.storage-service.enabled", matchIfMissing = true)
   public AmazonS3 awsS3MetadataClient(

--- a/front50-sql/front50-sql.gradle
+++ b/front50-sql/front50-sql.gradle
@@ -26,7 +26,7 @@ dependencies {
   testImplementation "dev.minutest:minutest:1.13.0"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
 
-  testImplementation "mysql:mysql-connector-java"
+  testImplementation "mysql:mysql-connector-java:8.0.12"
   testImplementation "org.testcontainers:mysql"
 
   testImplementation "org.testcontainers:postgresql"

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfigurationTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfigurationTests.kt
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.config
 
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.front50.config.CommonStorageServiceDAOConfig
 import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
 import com.netflix.spinnaker.front50.migrations.StorageServiceMigrator
@@ -65,10 +67,15 @@ internal class CompositeStorageServiceConfigurationTests {
 }
 
 @SpringBootApplication
-@Import(CommonStorageServiceDAOConfig::class, CompositeStorageServiceConfiguration::class, SqlConfiguration::class)
+@Import(CommonStorageServiceDAOConfig::class, CompositeStorageServiceConfiguration::class, SqlConfiguration::class, PluginsAutoConfiguration::class)
 @EnableConfigurationProperties(StorageServiceConfigurationProperties::class)
 internal class CompositeStorageServiceConfigurationTestApp {
   @Bean
   @ConditionalOnMissingBean
   fun contextProvider(): RequestContextProvider = AuthenticatedRequestContextProvider()
+
+  @Bean
+  @ConditionalOnMissingBean
+  fun getRegistry(): Registry = DefaultRegistry()
+
 }

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfigurationTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfigurationTests.kt
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.config
 
 
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.front50.config.CommonStorageServiceDAOConfig
 import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
 import com.netflix.spinnaker.front50.migrations.StorageServiceMigrator
@@ -66,10 +68,16 @@ internal class CompositeStorageServiceConfigurationTests {
 }
 
 @SpringBootApplication
-@Import(CommonStorageServiceDAOConfig::class, CompositeStorageServiceConfiguration::class, SqlConfiguration::class)
+@Import(CommonStorageServiceDAOConfig::class, CompositeStorageServiceConfiguration::class, SqlConfiguration::class, PluginsAutoConfiguration::class)
 @EnableConfigurationProperties(StorageServiceConfigurationProperties::class)
 internal class CompositeStorageServiceConfigurationTestApp {
   @Bean
   @ConditionalOnMissingBean
   fun contextProvider(): RequestContextProvider = AuthenticatedRequestContextProvider()
+
+
+  @Bean
+  @ConditionalOnMissingBean
+  fun getRegistry(): Registry = DefaultRegistry()
+
 }

--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfigurationTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfigurationTests.kt
@@ -16,8 +16,7 @@
 
 package com.netflix.spinnaker.config
 
-import com.netflix.spectator.api.DefaultRegistry
-import com.netflix.spectator.api.Registry
+
 import com.netflix.spinnaker.front50.config.CommonStorageServiceDAOConfig
 import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
 import com.netflix.spinnaker.front50.migrations.StorageServiceMigrator
@@ -67,15 +66,10 @@ internal class CompositeStorageServiceConfigurationTests {
 }
 
 @SpringBootApplication
-@Import(CommonStorageServiceDAOConfig::class, CompositeStorageServiceConfiguration::class, SqlConfiguration::class, PluginsAutoConfiguration::class)
+@Import(CommonStorageServiceDAOConfig::class, CompositeStorageServiceConfiguration::class, SqlConfiguration::class)
 @EnableConfigurationProperties(StorageServiceConfigurationProperties::class)
 internal class CompositeStorageServiceConfigurationTestApp {
   @Bean
   @ConditionalOnMissingBean
   fun contextProvider(): RequestContextProvider = AuthenticatedRequestContextProvider()
-
-  @Bean
-  @ConditionalOnMissingBean
-  fun getRegistry(): Registry = DefaultRegistry()
-
 }

--- a/front50-sql/src/test/resources/application.yml
+++ b/front50-sql/src/test/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
-  profiles: default
-
+  #profiles: default
+  config:
+    activate:
+      on-profile: default
 spinnaker:
   migration:
     enabled: true

--- a/front50-web/config/front50.yml
+++ b/front50-web/config/front50.yml
@@ -25,3 +25,6 @@ swagger:
     - /pipelines.*
     - /strategies.*
     - /v2/.*
+#logging:
+#  level:
+#    root: DEBUG

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/Main.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/Main.java
@@ -39,7 +39,13 @@ import org.springframework.scheduling.annotation.EnableScheduling;
       DataSourceAutoConfiguration.class,
       GsonAutoConfiguration.class
     })
-@ComponentScan({"com.netflix.spinnaker.front50", "com.netflix.spinnaker.config"})
+@ComponentScan({
+  "com.netflix.spinnaker.front50",
+  "com.netflix.spinnaker.config",
+  "com.netflix.spinnaker.kork",
+  "com.netflix.spectator.api",
+  "com.netflix.spinnaker.front50.config"
+})
 public class Main extends SpringBootServletInitializer {
 
   private static final Map<String, Object> DEFAULT_PROPS =


### PR DESCRIPTION
changes to update spring-core version 6.0.2 to 6.0.8

changes:
1. ref for changes to replace org/springframework/boot/test/context/ConfigFileApplicationContextInitializer class : 
GcsIntegrationTest.kt
https://javadoc.io/doc/org.springframework.boot/spring-boot-test/2.4.4/deprecated-list.html
and
https://javadoc.io/doc/org.springframework.boot/spring-boot-test/2.4.4/org/springframework/boot/test/context/ConfigDataApplicationContextInitializer.html
2. kotlin tests were failing
front50-api-tck/front50-api-tck.gradle
3. added/changes for DefaultRegistry bean - bean not found issue :
front50-gcs/front50-gcs.gradle
and 
front50-sql/src/test/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfigurationTests.kt
4. AWSCredentialsProvider bean should be referred from kork
 front50-s3/src/main/java/com/netflix/spinnaker/front50/config/S3Config.java
and 
front50-web/src/main/java/com/netflix/spinnaker/front50/Main.java
5. test profiles was not setting properly:
front50-sql/src/test/resources/application.yml