### PR TITLE
bugfix for OP-20338 NoSuchBeanDefinitionException: No qualifying bean…

### DIFF
--- a/front50-sql/src/test/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfigurationTests.kt
+++ b/front50-sql/src/test/kotlin/com/netflix/spinnaker/config/CompositeStorageServiceConfigurationTests.kt
@@ -17,8 +17,6 @@
 package com.netflix.spinnaker.config
 
 
-import com.netflix.spectator.api.DefaultRegistry
-import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.front50.config.CommonStorageServiceDAOConfig
 import com.netflix.spinnaker.front50.config.StorageServiceConfigurationProperties
 import com.netflix.spinnaker.front50.migrations.StorageServiceMigrator
@@ -75,9 +73,5 @@ internal class CompositeStorageServiceConfigurationTestApp {
   @ConditionalOnMissingBean
   fun contextProvider(): RequestContextProvider = AuthenticatedRequestContextProvider()
 
-
-  @Bean
-  @ConditionalOnMissingBean
-  fun getRegistry(): Registry = DefaultRegistry()
 
 }

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/config/Front50WebConfig.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/config/Front50WebConfig.java
@@ -16,7 +16,6 @@
  */
 package com.netflix.spinnaker.front50.config;
 
-import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.config.PluginsAutoConfiguration;
 import com.netflix.spinnaker.fiat.shared.EnableFiatAutoConfig;
@@ -39,6 +38,7 @@ import com.netflix.spinnaker.kork.web.context.AuthenticatedRequestContextProvide
 import com.netflix.spinnaker.kork.web.context.RequestContextProvider;
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor;
 import java.util.*;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -60,10 +60,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Import({PluginsAutoConfiguration.class})
 @EnableConfigurationProperties(StorageServiceConfigurationProperties.class)
 public class Front50WebConfig implements WebMvcConfigurer {
-  @Bean
-  public Registry getRegistry() {
-    return new DefaultRegistry();
-  }
+
+  @Autowired private Registry registry;
 
   @Bean
   public TaskScheduler taskScheduler() {
@@ -78,7 +76,7 @@ public class Front50WebConfig implements WebMvcConfigurer {
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(
         new MetricsInterceptor(
-            getRegistry(),
+            this.registry,
             "controller.invocations",
             new ArrayList<>(Arrays.asList("account", "application")),
             new ArrayList<>(Collections.singletonList("BasicErrorController"))));


### PR DESCRIPTION
Fixed as suggested in:
https://github.com/spring-projects/spring-boot/issues/33413

The 3.0 [release notes link to the dedicated migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes#upgrading-from-spring-boot-27), which is where most of the information needed when migrating from 2.7 to 3.0 is located.
and
https://medium.com/spring-boot/auto-configure-your-common-module-in-the-spring-boot-way-32acd3976a70