### PR TITLE
Remove Jooq to fetch from Kork-OES

### DIFF
--- a/front50-sql/front50-sql.gradle
+++ b/front50-sql/front50-sql.gradle
@@ -12,8 +12,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-exceptions"
   implementation "io.spinnaker.kork:kork-web"
   implementation "net.logstash.logback:logstash-logback-encoder:4.11"
-  api("org.jooq:jooq:3.13.6")
-  api("org.jooq:jooq-kotlin:3.13.6")
+ 
 
 
   implementation "io.strikt:strikt-core"


### PR DESCRIPTION
Remove Jooq to fetch from Kork-OES to avoid maintaining the version at multiple services.

