### PR TITLE
OP-22194-Fixed PipelineControllerSpec UTs & Readded synchronised in s…

### DIFF
--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/PipelineController.java
@@ -172,7 +172,7 @@ public class PipelineController {
   @PreAuthorize(
       "@fiatPermissionEvaluator.storeWholePermission() and  hasPermission(#pipeline.application, 'APPLICATION', 'WRITE') and  @authorizationSupport.hasRunAsUserPermission(#pipeline)")
   @RequestMapping(value = "", method = RequestMethod.POST)
-  public Pipeline save(
+  public synchronized Pipeline save(
       @RequestBody Pipeline pipeline,
       @RequestParam(value = "staleCheck", required = false, defaultValue = "false")
           Boolean staleCheck) {

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/TestConfiguration.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/TestConfiguration.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 OpsMx
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.front50
+
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
+import com.netflix.spinnaker.fiat.shared.FiatService
+import com.netflix.spinnaker.fiat.shared.FiatStatus
+import com.netflix.spinnaker.front50.config.FiatConfigurationProperties
+import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import spock.mock.DetachedMockFactory
+
+@Configuration
+class TestConfiguration {
+
+  DetachedMockFactory detachedMockFactory = new DetachedMockFactory()
+
+  @Bean
+  PipelineDAO pipelineDAO() {
+    return detachedMockFactory.Stub(PipelineDAO)
+  }
+
+  @Bean
+  FiatPermissionEvaluator fiatPermissionEvaluator() {
+    return detachedMockFactory.Stub(FiatPermissionEvaluator)
+  }
+
+  @Bean
+  FiatConfigurationProperties fiatConfigurationProperties() {
+    return detachedMockFactory.Stub(FiatConfigurationProperties)
+  }
+
+  @Bean
+  FiatStatus fiatStatus() {
+    return detachedMockFactory.Stub(FiatStatus)
+  }
+
+  @Bean
+  FiatService fiatService() {
+    return detachedMockFactory.Stub(FiatService)
+  }
+}
+

--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerSpec.groovy
@@ -8,6 +8,7 @@ import com.netflix.spinnaker.front50.model.pipeline.PipelineDAO
 import com.netflix.spinnaker.kork.web.exceptions.ExceptionMessageDecorator
 import com.netflix.spinnaker.kork.web.exceptions.GenericExceptionHandlers
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -23,7 +24,6 @@ import spock.lang.Specification
 import spock.lang.Unroll
 import spock.mock.DetachedMockFactory
 
-import jakarta.servlet.http.HttpServletResponse
 import java.util.concurrent.Executors
 import java.util.stream.Collectors
 
@@ -113,7 +113,7 @@ class PipelineControllerSpec extends Specification {
           new ObjectMapper(),
           Optional.empty(),
           [new MockValidator()] as List<PipelineValidator>,
-          Optional.empty(), fiatPermissionEvaluator, fiatService, fiatConfigurationProperties, fiatStatus
+          Optional.empty()
         )
       )
       .setControllerAdvice(
@@ -171,6 +171,38 @@ class PipelineControllerSpec extends Specification {
     response.contentAsString.contains("\"name\":\"test-pipeline\"")
     response.contentAsString.contains("\"application\":\"test-application\"")
     response.contentAsString.contains("\"updateTs\":\"1662644108709\"")
+  }
+
+  @Unroll
+  def "should create pipelines in a thread safe way"() {
+    given:
+    def pipelineDAO = new InMemoryPipelineDAO()
+    def createPipelineFirstRequest = post("/pipelines")
+      .contentType(MediaType.APPLICATION_JSON)
+      .content(new ObjectMapper().writeValueAsString([
+        id         : "1",
+        name       : "pipeline-name",
+        application: "application-name",
+      ]))
+    def createPipelineSecondRequest = post("/pipelines")
+      .contentType(MediaType.APPLICATION_JSON)
+      .content(new ObjectMapper().writeValueAsString([
+        id         : "2",
+        name       : "pipeline-name",
+        application: "application-name",
+      ]))
+
+    def mockMvcWithController = MockMvcBuilders.standaloneSetup(new PipelineController(
+      pipelineDAO, new ObjectMapper(), Optional.empty(), [], Optional.empty())).build()
+
+    when:
+    def all = Executors.newFixedThreadPool(2).invokeAll(List.of(
+      { -> mockMvcWithController.perform(createPipelineFirstRequest).andReturn().response },
+      { -> mockMvcWithController.perform(createPipelineSecondRequest).andReturn().response },
+    ))
+    then:
+    (all.get(0).get().status == 200 && all.get(1).get().status == 400) || (all.get(0).get().status == 400 && all.get(1).get().status == 200)
+
   }
 
   @Configuration


### PR DESCRIPTION
**Parent Jira** : https://devopsmx.atlassian.net/browse/OP-22085
**Jira** : https://devopsmx.atlassian.net/browse/OP-22194

**Summary** :
Supporting Change : https://github.com/spinnaker/front50/pull/1172/files
Found no strong reason to revert above change, so undoing the revert.

**Testing** : 
compile success, service starting locally, PipelineControllerSpec - 9/9 UT passed