### PR TITLE
OP-22194 - Fixed all remaining PipelineControllerTck UTs

### DIFF
--- a/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
+++ b/front50-web/src/test/groovy/com/netflix/spinnaker/front50/controllers/PipelineControllerTck.groovy
@@ -79,7 +79,9 @@ abstract class PipelineControllerTck extends Specification {
       isEnabled() >> true
     }
   }
-  FiatPermissionEvaluator fiatPermissionEvaluator = Mock(FiatPermissionEvaluator)
+  FiatPermissionEvaluator fiatPermissionEvaluator = Mock(FiatPermissionEvaluator) {
+    hasPermission(_, _, "PIPELINE", "READ") >> true
+  }
 
   @Subject
   PipelineDAO pipelineDAO


### PR DESCRIPTION
**Parent Jira** : https://devopsmx.atlassian.net/browse/OP-22085
**Jira** : https://devopsmx.atlassian.net/browse/OP-22194

**Summary** :
To support rbac changes, mocked hasPermission() to return true

**Testing** :
compile success, service starting locally, PipelineControllerTck - 32/32 UT passed