### PR TITLE
OP 22801: Bug fix on UnRecognised fields found in pipeline JSON 

### DIFF
--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -16,6 +16,8 @@
  */
 package com.netflix.spinnaker.front50.api.model.pipeline;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.netflix.spinnaker.front50.api.model.Timestamped;
@@ -35,6 +37,8 @@ public class Pipeline implements Timestamped {
   private Map<String, Object> anyMap = new HashMap<>();
 
   private Map<String, Object> appConfig = new HashMap<>();
+
+  private Map<String, Object> additionalFields = new HashMap<>();
 
   @Setter private String id;
   @Getter @Setter private String name;
@@ -96,6 +100,18 @@ public class Pipeline implements Timestamped {
   @Getter @Setter private Map<String, Object> variables = new HashMap<>();
 
   @Getter @Setter private List<Object> exclude;
+
+  // Captures any fields that are not explicitly defined
+  @JsonAnySetter
+  public void setAdditionalField(String key, Object value) {
+    additionalFields.put(key, value);
+  }
+
+  // Unrecognized fields are serialized back into JSON
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalFields() {
+    return additionalFields;
+  }
 
   public String getUpdateTs() {
     var lastModified = getLastModified();

--- a/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
+++ b/front50-api/src/main/java/com/netflix/spinnaker/front50/api/model/pipeline/Pipeline.java
@@ -16,12 +16,9 @@
  */
 package com.netflix.spinnaker.front50.api.model.pipeline;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.netflix.spinnaker.front50.api.model.Timestamped;
-import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -36,28 +33,13 @@ public class Pipeline implements Timestamped {
 
   private Map<String, Object> anyMap = new HashMap<>();
 
-  private Map<String, Object> appConfig = new HashMap<>();
-
-  private Map<String, Object> additionalFields = new HashMap<>();
-
   @Setter private String id;
   @Getter @Setter private String name;
   @Getter @Setter private String application;
-
-  @Getter @Setter private String description;
-
   @Getter @Setter private String type;
-
   @Setter private String schema;
-
   @Getter @Setter private Object config;
-
   @Getter @Setter private List<Trigger> triggers = new ArrayList<>();
-
-  @Getter @Setter private List<ExpectedArtifact> expectedArtifacts = new ArrayList<>();
-
-  @Getter @Setter private Map<String, Object> locked;
-
   @Getter @Setter private Integer index;
 
   private String createTs;
@@ -67,51 +49,20 @@ public class Pipeline implements Timestamped {
   @JsonIgnore @Getter @Setter private Long lastModified;
 
   @Getter @Setter private String email;
-
   @Getter @Setter private Boolean disabled;
-
   @Getter @Setter private Map<String, Object> template;
-
   @Getter @Setter private List<String> roles;
-
   @Getter @Setter private String serviceAccount;
-
   @Getter @Setter private String executionEngine;
-
   @Getter @Setter private Integer stageCounter;
-
   @Getter @Setter private List<Map<String, Object>> stages;
-
   @Getter @Setter private Map<String, Object> constraints;
-
   @Getter @Setter private Map<String, Object> payloadConstraints;
-
   @Getter @Setter private Boolean keepWaitingPipelines;
   @Getter @Setter private Boolean limitConcurrent;
-
   @Getter @Setter private Integer maxConcurrentExecutions;
-
   @Getter @Setter private List<Map<String, Object>> parameterConfig;
-
-  @Getter @Setter private List<Map<String, Object>> notifications;
-
   @Getter @Setter private String spelEvaluator;
-
-  @Getter @Setter private Map<String, Object> variables = new HashMap<>();
-
-  @Getter @Setter private List<Object> exclude;
-
-  // Captures any fields that are not explicitly defined
-  @JsonAnySetter
-  public void setAdditionalField(String key, Object value) {
-    additionalFields.put(key, value);
-  }
-
-  // Unrecognized fields are serialized back into JSON
-  @JsonAnyGetter
-  public Map<String, Object> getAdditionalFields() {
-    return additionalFields;
-  }
 
   public String getUpdateTs() {
     var lastModified = getLastModified();
@@ -125,14 +76,6 @@ public class Pipeline implements Timestamped {
 
   public Map<String, Object> getAny() {
     return anyMap;
-  }
-
-  public void setAppConfig(String key, Object value) {
-    appConfig.put(key, value);
-  }
-
-  public Map<String, Object> getAppConfig() {
-    return appConfig;
   }
 
   @Override

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/DeserializeCustomConfig.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/DeserializeCustomConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.front50.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DeserializeCustomConfig {
+
+  @Bean
+  public ObjectMapper objectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    return objectMapper;
+  }
+}

--- a/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/DeserializeCustomConfig.java
+++ b/front50-s3/src/main/java/com/netflix/spinnaker/front50/config/DeserializeCustomConfig.java
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.front50.config;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.front50.api.model.pipeline.Pipeline;
+import com.netflix.spinnaker.front50.jackson.mixins.PipelineMixins;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -28,6 +30,7 @@ public class DeserializeCustomConfig {
   public ObjectMapper objectMapper() {
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    objectMapper.addMixIn(Pipeline.class, PipelineMixins.class);
     return objectMapper;
   }
 }


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-22801
https://devopsmx.atlassian.net/browse/OP-22768

**Code Changes :** 
- Configured an ObjectMapper for Deserialization  on Unrecognised fields.
- Modified Pipeline class as like in OSS removing all added additional fields

**Tested**
Tested the code fix in https://samlisd0624.qabox.opsmx.org/
Pod is up without any issue
**Usecases:**
Adding new fields in pipeline JSON which aren't defined in pipeline class - saving succesfully.
Removed few existing fields from pipeline class and verified they're retained back without any issue.

pipeline saving succesfully with unrecognised fields(**regenerateCronTriggerIDs, usePriorExecution**) and fields that are removed from pipeline class which were added externally(**locked, expectedArtifacts**). ![Screenshot from 2024-10-16 13-30-56](https://github.com/user-attachments/assets/edd86af3-c6e4-4a47-adb8-9708661e0e4f)
![Screenshot from 2024-10-16 14-33-18](https://github.com/user-attachments/assets/a40ba892-85e6-4f55-9991-f09200b9cbd9)

![Screenshot from 2024-10-16 13-31-46](https://github.com/user-attachments/assets/9e6f1d7d-89f6-4b4b-9760-f17244318873)

